### PR TITLE
feature /.Qiita APIでQiitaの記事を取得・表示する機能を実装

### DIFF
--- a/backend/controller/qiita_controller.go
+++ b/backend/controller/qiita_controller.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"go-react-app/usecase"
+)
+
+type IQiitaController interface {
+	GetQiitaArticles(c echo.Context) error
+	GetQiitaArticleByID(c echo.Context) error
+}
+
+type qiitaController struct {
+	qu usecase.IQiitaUsecase
+}
+
+func NewQiitaController(qu usecase.IQiitaUsecase) IQiitaController {
+	return &qiitaController{qu}
+}
+
+func (qc *qiitaController) GetQiitaArticles(c echo.Context) error {
+	articles, err := qc.qu.GetQiitaArticles()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"message": err.Error(),
+		})
+	}
+	return c.JSON(http.StatusOK, articles)
+}
+
+func (qc *qiitaController) GetQiitaArticleByID(c echo.Context) error {
+	id := c.Param("id")
+	article, err := qc.qu.GetQiitaArticleByID(id)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"message": err.Error(),
+		})
+	}
+	return c.JSON(http.StatusOK, article)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -38,6 +38,10 @@ func main() {
 	externalAPIUsecase := usecase.NewExternalAPIUsecase(externalAPIRepository, externalAPIValidator)
 	externalAPIController := controller.NewExternalAPIController(externalAPIUsecase)
 
-	e := router.NewRouter(userController, taskController, feedController, externalAPIController)
+	qiitaRepository := repository.NewQiitaRepository()
+	qiitaUsecase := usecase.NewQiitaUsecase(qiitaRepository)
+	qiitaController := controller.NewQiitaController(qiitaUsecase)
+
+	e := router.NewRouter(userController, taskController, feedController, externalAPIController, qiitaController)
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/backend/model/qiita_article.go
+++ b/backend/model/qiita_article.go
@@ -1,0 +1,37 @@
+package model
+
+import "time"
+
+type QiitaArticle struct {
+	ID           string    `json:"id"`
+	Title        string    `json:"title"`
+	URL          string    `json:"url"`
+	Body         string    `json:"body"`
+	LikesCount   int       `json:"likes_count"`
+	ReactionsCount int     `json:"reactions_count"`
+	CommentsCount int      `json:"comments_count"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Tags         []QiitaTag `json:"tags"`
+	User         QiitaUser  `json:"user"`
+}
+
+type QiitaTag struct {
+	Name string `json:"name"`
+}
+
+type QiitaUser struct {
+	ID              string `json:"id"`
+	ProfileImageURL string `json:"profile_image_url"`
+	Name            string `json:"name"`
+}
+
+type QiitaArticleResponse struct {
+	ID           string    `json:"id"`
+	Title        string    `json:"title"`
+	URL          string    `json:"url"`
+	LikesCount   int       `json:"likes_count"`
+	Tags         []QiitaTag `json:"tags"`
+	CreatedAt    time.Time `json:"created_at"`
+	User         QiitaUser  `json:"user"`
+}

--- a/backend/repository/qiita_repository.go
+++ b/backend/repository/qiita_repository.go
@@ -1,0 +1,83 @@
+package repository
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"go-react-app/model"
+)
+
+type IQiitaRepository interface {
+	GetQiitaArticles() ([]model.QiitaArticle, error)
+	GetQiitaArticleByID(id string) (model.QiitaArticle, error)
+}
+
+type qiitaRepository struct {
+	baseURL string
+	token   string
+}
+
+func NewQiitaRepository() IQiitaRepository {
+	return &qiitaRepository{
+		baseURL: "https://qiita.com/api/v2",
+		token:   os.Getenv("QIITA_ACCESS_TOKEN"),
+	}
+}
+
+func (qr *qiitaRepository) GetQiitaArticles() ([]model.QiitaArticle, error) {
+	url := fmt.Sprintf("%s/items", qr.baseURL)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+qr.token)
+	
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status code: %d", resp.StatusCode)
+	}
+
+	var articles []model.QiitaArticle
+	if err := json.NewDecoder(resp.Body).Decode(&articles); err != nil {
+		return nil, err
+	}
+
+	return articles, nil
+}
+
+func (qr *qiitaRepository) GetQiitaArticleByID(id string) (model.QiitaArticle, error) {
+	url := fmt.Sprintf("%s/items/%s", qr.baseURL, id)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return model.QiitaArticle{}, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+qr.token)
+	
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return model.QiitaArticle{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return model.QiitaArticle{}, fmt.Errorf("API request failed with status code: %d", resp.StatusCode)
+	}
+
+	var article model.QiitaArticle
+	if err := json.NewDecoder(resp.Body).Decode(&article); err != nil {
+		return model.QiitaArticle{}, err
+	}
+
+	return article, nil
+}

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -10,7 +10,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func NewRouter(uc controller.IUserController, tc controller.ITaskController, fc controller.IFeedController, ac controller.IExternalAPIController) *echo.Echo {
+func NewRouter(uc controller.IUserController, tc controller.ITaskController, fc controller.IFeedController, ac controller.IExternalAPIController, qc controller.IQiitaController) *echo.Echo {
 	e := echo.New()
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"http://localhost:3000", os.Getenv("FE_URL")},
@@ -67,6 +67,16 @@ func NewRouter(uc controller.IUserController, tc controller.ITaskController, fc 
 	a.POST("", ac.CreateExternalAPI)
 	a.PUT("/:apiId", ac.UpdateExternalAPI)
 	a.DELETE("/:apiId", ac.DeleteExternalAPI)
+	
+	// 外部API関連のルート
+	q := e.Group("/qiita")
+	q.Use(echojwt.WithConfig(echojwt.Config{
+		SigningKey:  []byte(os.Getenv("SECRET")),
+		TokenLookup: "cookie:token",
+	}))
+	q.GET("/articles", qc.GetQiitaArticles)
+	q.GET("/articles/:id", qc.GetQiitaArticleByID)
 
 	return e
 }
+

--- a/backend/usecase/qiita_usecase.go
+++ b/backend/usecase/qiita_usecase.go
@@ -1,0 +1,60 @@
+package usecase
+
+import (
+	"go-react-app/model"
+	"go-react-app/repository"
+)
+
+type IQiitaUsecase interface {
+	GetQiitaArticles() ([]model.QiitaArticleResponse, error)
+	GetQiitaArticleByID(id string) (model.QiitaArticleResponse, error)
+}
+
+type qiitaUsecase struct {
+	qr repository.IQiitaRepository
+}
+
+func NewQiitaUsecase(qr repository.IQiitaRepository) IQiitaUsecase {
+	return &qiitaUsecase{qr}
+}
+
+func (qu *qiitaUsecase) GetQiitaArticles() ([]model.QiitaArticleResponse, error) {
+	articles, err := qu.qr.GetQiitaArticles()
+	if err != nil {
+		return nil, err
+	}
+
+	var response []model.QiitaArticleResponse
+	for _, article := range articles {
+		response = append(response, model.QiitaArticleResponse{
+			ID:           article.ID,
+			Title:        article.Title,
+			URL:          article.URL,
+			LikesCount:   article.LikesCount,
+			Tags:         article.Tags,
+			CreatedAt:    article.CreatedAt,
+			User:         article.User,
+		})
+	}
+
+	return response, nil
+}
+
+func (qu *qiitaUsecase) GetQiitaArticleByID(id string) (model.QiitaArticleResponse, error) {
+	article, err := qu.qr.GetQiitaArticleByID(id)
+	if err != nil {
+		return model.QiitaArticleResponse{}, err
+	}
+
+	response := model.QiitaArticleResponse{
+		ID:           article.ID,
+		Title:        article.Title,
+		URL:          article.URL,
+		LikesCount:   article.LikesCount,
+		Tags:         article.Tags,
+		CreatedAt:    article.CreatedAt,
+		User:         article.User,
+	}
+
+	return response, nil
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.0.16",
-        "@tanstack/react-query": "^4.28.0",
+        "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.28.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@heroicons/react": "^2.0.16",
-    "@tanstack/react-query": "^4.28.0",
+    "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.28.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Feed } from './components/Feed'
 import { ExternalAPIManager } from './components/ExternalAPIManager'
 import axios from 'axios'
 import { CsrfToken } from './types'
+import { QiitaPage } from './pages/QiitaPage'
 
 function App() {
   useEffect(() => {
@@ -25,6 +26,7 @@ function App() {
         <Route path="/todo" element={<Todo />} />
         <Route path="/feed" element={<Feed />} />
         <Route path="/external-api-manager" element={<ExternalAPIManager />} />
+        <Route path="/qiita-articles" element={<QiitaPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/components/QiitaArticleItem.tsx
+++ b/frontend/src/components/QiitaArticleItem.tsx
@@ -1,0 +1,46 @@
+import { FC } from 'react'
+import { QiitaArticle } from '../types'
+
+type Props = {
+  article: QiitaArticle
+}
+
+export const QiitaArticleItem: FC<Props> = ({ article }) => {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('ja-JP')
+  }
+
+  return (
+    <li className="qiita-item">
+      <div className="qiita-content">
+        <h3 className="qiita-title">
+          <a href={article.url} target="_blank" rel="noopener noreferrer">
+            {article.title}
+          </a>
+        </h3>
+        <div className="qiita-meta">
+          <div className="qiita-user">
+            <img 
+              src={article.user.profile_image_url} 
+              alt={article.user.id} 
+              className="qiita-user-image" 
+            />
+            <span>{article.user.id}</span>
+          </div>
+          <div className="qiita-info">
+            <span className="qiita-date">{formatDate(article.created_at)}</span>
+            <span className="qiita-likes">♥ {article.likes_count}</span>
+          </div>
+        </div>
+        <div className="qiita-tags">
+          {article.tags.map((tag) => (
+            <span key={tag.name} className="qiita-tag">
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      </div>
+    </li>
+  )
+}

--- a/frontend/src/components/QiitaArticleList.tsx
+++ b/frontend/src/components/QiitaArticleList.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react'
+import { useQueryQiitaArticles } from '../hooks/useQueryQiitaArticles'
+import { QiitaArticleItem } from './QiitaArticleItem'
+
+export const QiitaArticleList: FC = () => {
+  const { data: articles, isLoading, isError } = useQueryQiitaArticles()
+
+  if (isLoading) return <div>読み込み中...</div>
+  if (isError) return <div>エラーが発生しました</div>
+  if (!articles || articles.length === 0) return <div>記事がありません</div>
+
+  return (
+    <div className="qiita-container">
+      <h2 className="qiita-header">Qiita記事一覧</h2>
+      <ul className="qiita-list">
+        {articles.map((article) => (
+          <QiitaArticleItem key={article.id} article={article} />
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useQueryQiitaArticles.ts
+++ b/frontend/src/hooks/useQueryQiitaArticles.ts
@@ -1,0 +1,20 @@
+import axios from 'axios'
+import { useQuery } from '@tanstack/react-query'
+import { QiitaArticle } from '../types'
+
+export const useQueryQiitaArticles = () => {
+  const getQiitaArticles = async () => {
+    const { data } = await axios.get<QiitaArticle[]>(
+      `${process.env.REACT_APP_API_URL}/qiita/articles`,
+      { withCredentials: true }
+    )
+    return data
+  }
+
+  return useQuery<QiitaArticle[], Error>({
+    queryKey: ['qiitaArticles'],
+    queryFn: getQiitaArticles,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  })
+}

--- a/frontend/src/pages/QiitaPage.tsx
+++ b/frontend/src/pages/QiitaPage.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react'
+import { QiitaArticleList } from '../components/QiitaArticleList'
+import '../styles/QiitaArticle.css'
+
+export const QiitaPage: FC = () => {
+  return (
+    <div className="container">
+      <QiitaArticleList />
+    </div>
+  )
+}

--- a/frontend/src/styles/QiitaArticle.css
+++ b/frontend/src/styles/QiitaArticle.css
@@ -1,0 +1,81 @@
+.qiita-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.qiita-header {
+  margin-bottom: 20px;
+  font-size: 24px;
+  color: #333;
+}
+
+.qiita-list {
+  list-style: none;
+  padding: 0;
+}
+
+.qiita-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.qiita-title {
+  margin: 0 0 12px 0;
+  font-size: 18px;
+}
+
+.qiita-title a {
+  color: #55c500;
+  text-decoration: none;
+}
+
+.qiita-title a:hover {
+  text-decoration: underline;
+}
+
+.qiita-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.qiita-user {
+  display: flex;
+  align-items: center;
+}
+
+.qiita-user-image {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  margin-right: 8px;
+}
+
+.qiita-info {
+  font-size: 14px;
+  color: #666;
+}
+
+.qiita-date {
+  margin-right: 12px;
+}
+
+.qiita-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.qiita-tag {
+  background-color: #f1f8ff;
+  color: #0366d6;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -30,3 +30,23 @@ export type ExternalAPI = {
   created_at: string
   updated_at: string
 }
+
+export type QiitaTag = {
+  name: string
+}
+
+export type QiitaUser = {
+  id: string
+  profile_image_url: string
+  name: string
+}
+
+export type QiitaArticle = {
+  id: string
+  title: string
+  url: string
+  likes_count: number
+  tags: QiitaTag[]
+  created_at: string
+  user: QiitaUser
+}


### PR DESCRIPTION
### 概要
<!-- このプルリクエストが何を解決するためのものであるか簡潔に記載してください -->
 - Qiita APIでQiitaの記事を取得・表示する機能を実装

### 変更内容
<!-- このプルリクエストで具体的に何を変更したのか、またその理由を説明してください -->
 - backend (GO)
   - clean architectureでQiitaAPIでQiitaの記事を取得するapiを実装
     - データベースへの保存までは実装せず、Qiita APIから直接取得・表示
 - frontend (React)
   - backend側で取得したQiitaの記事を表示 

### 動作確認方法
<!-- 動作確認の手順や注意事項を記載してください -->
 - backend (GO)
   - postmanでQiitaの記事を取得できることを確認
     - http://localhost:8080/qiita/articles (GET)
 - frontend (React)
   - backend側で取得したQiitaの記事を表示 

### 関連するIssueやプルリクエスト
<!-- 関連するIssueやプルリクエストがあればリンクを記載してください -->
- Related Issue: close #14
- Related PR: none
