### PR TITLE
feature/Layout-LayoutComponentを関連づけたCRUDのバックエンドapiを実装

### DIFF
--- a/backend/controller/layout_component_controller.go
+++ b/backend/controller/layout_component_controller.go
@@ -16,8 +16,68 @@ type ILayoutComponentController interface {
 	CreateLayoutComponent(c echo.Context) error
 	UpdateLayoutComponent(c echo.Context) error
 	DeleteLayoutComponent(c echo.Context) error
+	
+	// 新しいメソッド
+	AssignToLayout(c echo.Context) error
+	RemoveFromLayout(c echo.Context) error
+	UpdatePosition(c echo.Context) error
 }
 
+func (lcc *layoutComponentController) AssignToLayout(c echo.Context) error {
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(jwt.MapClaims)
+	userId := claims["user_id"]
+	
+	componentId, _ := strconv.Atoi(c.Param("componentId"))
+	layoutId, _ := strconv.Atoi(c.Param("layoutId"))
+	
+	var position map[string]int
+	if err := c.Bind(&position); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+	
+	err := lcc.lcu.AssignToLayout(uint(userId.(float64)), uint(componentId), uint(layoutId), position)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+	
+	return c.NoContent(http.StatusOK)
+}
+
+func (lcc *layoutComponentController) RemoveFromLayout(c echo.Context) error {
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(jwt.MapClaims)
+	userId := claims["user_id"]
+	
+	componentId, _ := strconv.Atoi(c.Param("componentId"))
+	
+	err := lcc.lcu.RemoveFromLayout(uint(userId.(float64)), uint(componentId))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+	
+	return c.NoContent(http.StatusOK)
+}
+
+func (lcc *layoutComponentController) UpdatePosition(c echo.Context) error {
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(jwt.MapClaims)
+	userId := claims["user_id"]
+	
+	componentId, _ := strconv.Atoi(c.Param("componentId"))
+	
+	var position map[string]int
+	if err := c.Bind(&position); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+	
+	err := lcc.lcu.UpdatePosition(uint(userId.(float64)), uint(componentId), position)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+	
+	return c.NoContent(http.StatusOK)
+}
 type layoutComponentController struct {
 	lcu usecase.ILayoutComponentUsecase
 }

--- a/backend/model/layout.go
+++ b/backend/model/layout.go
@@ -3,17 +3,19 @@ package model
 import "time"
 
 type Layout struct {
-	ID        uint      `json:"id" gorm:"primaryKey"`
-	Title     string    `json:"title" gorm:"not null"`
-	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
-	User      User      `json:"user" gorm:"foreignKey:UserId;constraint:OnDelete:CASCADE"`
-	UserId    uint      `json:"user_id" gorm:"not null"`
+	ID         uint              `json:"id" gorm:"primaryKey"`
+	Title      string            `json:"title" gorm:"not null"`
+	UserId     uint              `json:"user_id" gorm:"not null"`
+	User       User              `json:"user" gorm:"foreignKey:UserId"`
+	Components []LayoutComponent `json:"components" gorm:"foreignKey:LayoutId"`
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
 }
 
 type LayoutResponse struct {
-	ID        uint      `json:"id"`
-	Title     string    `json:"title"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID         uint                     `json:"id"`
+	Title      string                   `json:"title"`
+	Components []LayoutComponentResponse `json:"components,omitempty"`
+	CreatedAt  time.Time                `json:"created_at"`
+	UpdatedAt  time.Time                `json:"updated_at"`
 }

--- a/backend/model/layout_component.go
+++ b/backend/model/layout_component.go
@@ -5,12 +5,18 @@ import "time"
 type LayoutComponent struct {
 	ID        uint      `json:"id" gorm:"primaryKey"`
 	Name      string    `json:"name" gorm:"not null"`
-	Type      string    `json:"type" gorm:"not null"` // header, footer, sidebar, etc.
-	Content   string    `json:"content"`              // HTMLやJSONなどのコンテンツ
-	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
-	User      User      `json:"user" gorm:"foreignKey:UserId;constraint:OnDelete:CASCADE"`
+	Type      string    `json:"type" gorm:"not null"`
+	Content   string    `json:"content"`
+	X         int       `json:"x" gorm:"default:0"` // X座標位置
+	Y         int       `json:"y" gorm:"default:0"` // Y座標位置
+	Width     int       `json:"width" gorm:"default:100"` // 幅
+	Height    int       `json:"height" gorm:"default:100"` // 高さ
 	UserId    uint      `json:"user_id" gorm:"not null"`
+	User      User      `json:"user" gorm:"foreignKey:UserId"`
+	LayoutId  *uint     `json:"layout_id"` // nullableにする
+	Layout    *Layout   `json:"layout" gorm:"foreignKey:LayoutId"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type LayoutComponentResponse struct {
@@ -18,6 +24,11 @@ type LayoutComponentResponse struct {
 	Name      string    `json:"name"`
 	Type      string    `json:"type"`
 	Content   string    `json:"content"`
+	X         int       `json:"x"`
+	Y         int       `json:"y"`
+	Width     int       `json:"width"`
+	Height    int       `json:"height"`
+	LayoutId  *uint     `json:"layout_id,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/backend/repository/layout_component_repository.go
+++ b/backend/repository/layout_component_repository.go
@@ -14,6 +14,9 @@ type ILayoutComponentRepository interface {
 	CreateLayoutComponent(component *model.LayoutComponent) error
 	UpdateLayoutComponent(component *model.LayoutComponent, userId uint, componentId uint) error
 	DeleteLayoutComponent(userId uint, componentId uint) error
+	AssignToLayout(componentId uint, layoutId uint, userId uint, position map[string]int) error
+	RemoveFromLayout(componentId uint, userId uint) error
+	UpdatePosition(componentId uint, userId uint, position map[string]int) error
 }
 
 type layoutComponentRepository struct {
@@ -69,4 +72,57 @@ func (lcr *layoutComponentRepository) DeleteLayoutComponent(userId uint, compone
 		return fmt.Errorf("layout component does not exist")
 	}
 	return nil
+}
+
+func (lcr *layoutComponentRepository) AssignToLayout(componentId uint, layoutId uint, userId uint, position map[string]int) error {
+    result := lcr.db.Model(&model.LayoutComponent{}).
+        Where("id = ? AND user_id = ?", componentId, userId).
+        Updates(map[string]interface{}{
+            "layout_id": layoutId,
+            "x": position["x"],
+            "y": position["y"],
+            "width": position["width"],
+            "height": position["height"],
+        })
+    
+    if result.Error != nil {
+        return result.Error
+    }
+    if result.RowsAffected < 1 {
+        return fmt.Errorf("layout component does not exist or already assigned")
+    }
+    return nil
+}
+
+func (lcr *layoutComponentRepository) RemoveFromLayout(componentId uint, userId uint) error {
+    result := lcr.db.Model(&model.LayoutComponent{}).
+        Where("id = ? AND user_id = ?", componentId, userId).
+        Update("layout_id", nil)
+    
+    if result.Error != nil {
+        return result.Error
+    }
+    if result.RowsAffected < 1 {
+        return fmt.Errorf("layout component does not exist")
+    }
+    return nil
+}
+
+func (lcr *layoutComponentRepository) UpdatePosition(componentId uint, userId uint, position map[string]int) error {
+    result := lcr.db.Model(&model.LayoutComponent{}).
+        Where("id = ? AND user_id = ?", componentId, userId).
+        Updates(map[string]interface{}{
+            "x": position["x"],
+            "y": position["y"],
+            "width": position["width"],
+            "height": position["height"],
+        })
+    
+    if result.Error != nil {
+        return result.Error
+    }
+    if result.RowsAffected < 1 {
+        return fmt.Errorf("layout component does not exist")
+    }
+    return nil
 }

--- a/backend/repository/layout_repository.go
+++ b/backend/repository/layout_repository.go
@@ -32,7 +32,7 @@ func (lr *layoutRepository) GetAllLayouts(layouts *[]model.Layout, userId uint) 
 }
 
 func (lr *layoutRepository) GetLayoutById(layout *model.Layout, userId uint, layoutId uint) error {
-	if err := lr.db.Joins("User").Where("user_id=?", userId).First(layout, layoutId).Error; err != nil {
+	if err := lr.db.Preload("Components").Joins("User").Where("user_id=?", userId).First(layout, layoutId).Error; err != nil {
 		return err
 	}
 	return nil

--- a/backend/router/routes/layout_components.go
+++ b/backend/router/routes/layout_components.go
@@ -10,10 +10,14 @@ func SetupLayoutComponentRoutes(e *echo.Echo, lcc controller.ILayoutComponentCon
 	lc := e.Group("/layout-components")
 	lc.Use(middleware.GetJWTMiddleware())
 	
-	// ルートの設定
+	// 既存のルート
 	lc.GET("", lcc.GetAllLayoutComponents)
 	lc.GET("/:componentId", lcc.GetLayoutComponentById)
 	lc.POST("", lcc.CreateLayoutComponent)
 	lc.PUT("/:componentId", lcc.UpdateLayoutComponent)
 	lc.DELETE("/:componentId", lcc.DeleteLayoutComponent)
+	
+	lc.POST("/:componentId/assign/:layoutId", lcc.AssignToLayout)
+	lc.DELETE("/:componentId/assign", lcc.RemoveFromLayout)
+	lc.PUT("/:componentId/position", lcc.UpdatePosition)
 }

--- a/backend/usecase/layout_component_usecase.go
+++ b/backend/usecase/layout_component_usecase.go
@@ -12,8 +12,23 @@ type ILayoutComponentUsecase interface {
 	CreateLayoutComponent(component model.LayoutComponent) (model.LayoutComponentResponse, error)
 	UpdateLayoutComponent(component model.LayoutComponent, userId uint, componentId uint) (model.LayoutComponentResponse, error)
 	DeleteLayoutComponent(userId uint, componentId uint) error
+	
+	AssignToLayout(userId uint, componentId uint, layoutId uint, position map[string]int) error
+	RemoveFromLayout(userId uint, componentId uint) error
+	UpdatePosition(userId uint, componentId uint, position map[string]int) error
 }
 
+func (lcu *layoutComponentUsecase) AssignToLayout(userId uint, componentId uint, layoutId uint, position map[string]int) error {
+	return lcu.lcr.AssignToLayout(componentId, layoutId, userId, position)
+}
+
+func (lcu *layoutComponentUsecase) RemoveFromLayout(userId uint, componentId uint) error {
+	return lcu.lcr.RemoveFromLayout(componentId, userId)
+}
+
+func (lcu *layoutComponentUsecase) UpdatePosition(userId uint, componentId uint, position map[string]int) error {
+	return lcu.lcr.UpdatePosition(componentId, userId, position)
+}
 type layoutComponentUsecase struct {
 	lcr repository.ILayoutComponentRepository
 	lcv validator.ILayoutComponentValidator


### PR DESCRIPTION
## 概要
### レイアウトとコンポーネント管理機能の拡張
 - ブログCMSのレイアウト管理機能を拡張
 - レイアウトコンポーネントの位置情報管理と、レイアウトへの割り当て機能を追加
   - ユーザーはブログのレイアウトをより柔軟にカスタマイズできるようにするためのapi

## 変更内容

### モデルの拡張
- `LayoutComponent` モデルに位置情報（X, Y, Width, Height）を追加
- `LayoutComponent` と `Layout` の関連付けを実装
- レスポンスモデルも対応する形で更新

### リポジトリ層の拡張
- `ILayoutComponentRepository` インターフェースに以下のメソッドを追加:
  - `AssignToLayout`: コンポーネントをレイアウトに割り当て
  - `RemoveFromLayout`: レイアウトからコンポーネントを削除
  - `UpdatePosition`: コンポーネントの位置情報を更新

### ユースケース層の拡張
- `ILayoutComponentUsecase` インターフェースに対応するメソッドを追加
- 各メソッドの実装を追加

### コントローラー層の拡張
- `ILayoutComponentController` インターフェースに新しいエンドポイント用のメソッドを追加
- 各エンドポイントの実装を追加:
  - `AssignToLayout`: コンポーネントをレイアウトに割り当て
  - `RemoveFromLayout`: レイアウトからコンポーネントを削除
  - `UpdatePosition`: コンポーネントの位置情報を更新

### ルーティングの追加
- 新しいエンドポイントのルーティングを設定:
  - `POST /:componentId/assign/:layoutId`: コンポーネントをレイアウトに割り当て
  - `DELETE /:componentId/assign`: レイアウトからコンポーネントを削除
  - `PUT /:componentId/position`: コンポーネントの位置情報を更新

## 技術的詳細
- コンポーネントの位置情報は、グリッドベースのレイアウトシステムを想定し、X座標、Y座標、幅、高さを管理
- レイアウトとコンポーネントの関連付けは、`LayoutId`を使用した1対多の関係
- レイアウト割り当て時に位置情報も同時に設定可能

## 今後の展望
- フロントエンドでのドラッグ&ドロップインターフェースとの連携
- コンポーネント間の重なり検出と自動調整機能
- レイアウトテンプレート機能の追加
