### PR TITLE
Refactor/type errors refinement by swagger and typescript openai article model

### DIFF
--- a/backend/controller/article_controller.go
+++ b/backend/controller/article_controller.go
@@ -25,6 +25,15 @@ func NewArticleController(au usecase.IArticleUsecase) IArticleController {
 	return &articleController{au}
 }
 
+// GetAllArticles ユーザーのすべての記事を取得
+// @Summary ユーザーの記事一覧を取得
+// @Description ログインユーザーのすべての記事を取得する
+// @Tags articles
+// @Accept json
+// @Produce json
+// @Success 200 {array} model.ArticleResponse
+// @Failure 500 {object} map[string]string
+// @Router /articles [get]
 func (ac *articleController) GetAllArticles(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -35,6 +44,17 @@ func (ac *articleController) GetAllArticles(c echo.Context) error {
 	return c.JSON(http.StatusOK, articlesRes)
 }
 
+// GetArticleById 指定されたIDの記事を取得
+// @Summary 特定の記事を取得
+// @Description 指定されたIDの記事を取得する
+// @Tags articles
+// @Accept json
+// @Produce json
+// @Param articleId path int true "記事ID"
+// @Success 200 {object} model.ArticleResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /articles/{articleId} [get]
 func (ac *articleController) GetArticleById(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -51,6 +71,17 @@ func (ac *articleController) GetArticleById(c echo.Context) error {
 	return c.JSON(http.StatusOK, articleRes)
 }
 
+// CreateArticle 新しい記事を作成
+// @Summary 新しい記事を作成
+// @Description ユーザーの新しい記事を作成する
+// @Tags articles
+// @Accept json
+// @Produce json
+// @Param article body model.ArticleRequest true "記事情報"
+// @Success 201 {object} model.ArticleResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /articles [post]
 func (ac *articleController) CreateArticle(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -67,6 +98,18 @@ func (ac *articleController) CreateArticle(c echo.Context) error {
 	return c.JSON(http.StatusCreated, articleRes)
 }
 
+// UpdateArticle 既存の記事を更新
+// @Summary 記事を更新
+// @Description 指定されたIDの記事を更新する
+// @Tags articles
+// @Accept json
+// @Produce json
+// @Param articleId path int true "記事ID"
+// @Param article body model.ArticleRequest true "更新する記事情報"
+// @Success 200 {object} model.ArticleResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /articles/{articleId} [put]
 func (ac *articleController) UpdateArticle(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -89,6 +132,17 @@ func (ac *articleController) UpdateArticle(c echo.Context) error {
 	return c.JSON(http.StatusOK, articleRes)
 }
 
+// DeleteArticle 記事を削除
+// @Summary 記事を削除
+// @Description 指定されたIDの記事を削除する
+// @Tags articles
+// @Accept json
+// @Produce json
+// @Param articleId path int true "記事ID"
+// @Success 204 "No Content"
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /articles/{articleId} [delete]
 func (ac *articleController) DeleteArticle(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -15,6 +15,243 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/articles": {
+            "get": {
+                "description": "ログインユーザーのすべての記事を取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "ユーザーの記事一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.ArticleResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "ユーザーの新しい記事を作成する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "新しい記事を作成",
+                "parameters": [
+                    {
+                        "description": "記事情報",
+                        "name": "article",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/articles/{articleId}": {
+            "get": {
+                "description": "指定されたIDの記事を取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "特定の記事を取得",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "記事ID",
+                        "name": "articleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "指定されたIDの記事を更新する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "記事を更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "記事ID",
+                        "name": "articleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新する記事情報",
+                        "name": "article",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "指定されたIDの記事を削除する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "記事を削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "記事ID",
+                        "name": "articleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/csrf-token": {
             "get": {
                 "description": "CSRFトークンを取得する",
@@ -404,6 +641,63 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "model.ArticleRequest": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "Goは静的型付け言語です..."
+                },
+                "published": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "tags": {
+                    "type": "string",
+                    "example": "Go,プログラミング,チュートリアル"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Goプログラミングの基礎"
+                }
+            }
+        },
+        "model.ArticleResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "Goは静的型付け言語です..."
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "published": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "tags": {
+                    "type": "string",
+                    "example": "Go,プログラミング,チュートリアル"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Goプログラミングの基礎"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
+                }
+            }
+        },
         "model.CsrfTokenResponse": {
             "type": "object",
             "properties": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12,6 +12,243 @@
     "host": "localhost:8080",
     "basePath": "/api",
     "paths": {
+        "/articles": {
+            "get": {
+                "description": "ログインユーザーのすべての記事を取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "ユーザーの記事一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.ArticleResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "ユーザーの新しい記事を作成する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "新しい記事を作成",
+                "parameters": [
+                    {
+                        "description": "記事情報",
+                        "name": "article",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/articles/{articleId}": {
+            "get": {
+                "description": "指定されたIDの記事を取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "特定の記事を取得",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "記事ID",
+                        "name": "articleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "指定されたIDの記事を更新する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "記事を更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "記事ID",
+                        "name": "articleId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新する記事情報",
+                        "name": "article",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.ArticleResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "指定されたIDの記事を削除する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "articles"
+                ],
+                "summary": "記事を削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "記事ID",
+                        "name": "articleId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/csrf-token": {
             "get": {
                 "description": "CSRFトークンを取得する",
@@ -401,6 +638,63 @@
         }
     },
     "definitions": {
+        "model.ArticleRequest": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "Goは静的型付け言語です..."
+                },
+                "published": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "tags": {
+                    "type": "string",
+                    "example": "Go,プログラミング,チュートリアル"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Goプログラミングの基礎"
+                }
+            }
+        },
+        "model.ArticleResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "example": "Goは静的型付け言語です..."
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "published": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "tags": {
+                    "type": "string",
+                    "example": "Go,プログラミング,チュートリアル"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Goプログラミングの基礎"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
+                }
+            }
+        },
         "model.CsrfTokenResponse": {
             "type": "object",
             "properties": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,5 +1,46 @@
 basePath: /api
 definitions:
+  model.ArticleRequest:
+    properties:
+      content:
+        example: Goは静的型付け言語です...
+        type: string
+      published:
+        example: true
+        type: boolean
+      tags:
+        example: Go,プログラミング,チュートリアル
+        type: string
+      title:
+        example: Goプログラミングの基礎
+        type: string
+    required:
+    - title
+    type: object
+  model.ArticleResponse:
+    properties:
+      content:
+        example: Goは静的型付け言語です...
+        type: string
+      created_at:
+        example: "2023-01-01T00:00:00Z"
+        type: string
+      id:
+        example: 1
+        type: integer
+      published:
+        example: true
+        type: boolean
+      tags:
+        example: Go,プログラミング,チュートリアル
+        type: string
+      title:
+        example: Goプログラミングの基礎
+        type: string
+      updated_at:
+        example: "2023-01-01T00:00:00Z"
+        type: string
+    type: object
   model.CsrfTokenResponse:
     properties:
       csrf_token:
@@ -70,6 +111,163 @@ info:
   title: Blog CMS API
   version: "1.0"
 paths:
+  /articles:
+    get:
+      consumes:
+      - application/json
+      description: ログインユーザーのすべての記事を取得する
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.ArticleResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: ユーザーの記事一覧を取得
+      tags:
+      - articles
+    post:
+      consumes:
+      - application/json
+      description: ユーザーの新しい記事を作成する
+      parameters:
+      - description: 記事情報
+        in: body
+        name: article
+        required: true
+        schema:
+          $ref: '#/definitions/model.ArticleRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.ArticleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 新しい記事を作成
+      tags:
+      - articles
+  /articles/{articleId}:
+    delete:
+      consumes:
+      - application/json
+      description: 指定されたIDの記事を削除する
+      parameters:
+      - description: 記事ID
+        in: path
+        name: articleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 記事を削除
+      tags:
+      - articles
+    get:
+      consumes:
+      - application/json
+      description: 指定されたIDの記事を取得する
+      parameters:
+      - description: 記事ID
+        in: path
+        name: articleId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.ArticleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 特定の記事を取得
+      tags:
+      - articles
+    put:
+      consumes:
+      - application/json
+      description: 指定されたIDの記事を更新する
+      parameters:
+      - description: 記事ID
+        in: path
+        name: articleId
+        required: true
+        type: integer
+      - description: 更新する記事情報
+        in: body
+        name: article
+        required: true
+        schema:
+          $ref: '#/definitions/model.ArticleRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.ArticleResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 記事を更新
+      tags:
+      - articles
   /csrf-token:
     get:
       consumes:

--- a/backend/model/article.go
+++ b/backend/model/article.go
@@ -15,26 +15,25 @@ type Article struct {
 	UserId    uint      `json:"user_id" gorm:"not null"`
 }
 
-// リクエスト用の構造体
+// ArticleRequest 記事作成・更新リクエスト
 type ArticleRequest struct {
-	Title     string `json:"title" validate:"required"`
-	Content   string `json:"content"`
-	Published bool   `json:"published"`
-	Tags      string `json:"tags"`
+	Title     string `json:"title" validate:"required" example:"Goプログラミングの基礎"`
+	Content   string `json:"content" example:"Goは静的型付け言語です..."`
+	Published bool   `json:"published" example:"true"`
+	Tags      string `json:"tags" example:"Go,プログラミング,チュートリアル"`
 	UserId    uint   `json:"-"` // クライアントからは送信されず、JWTから取得
 }
 
-// レスポンス用の構造体
+// ArticleResponse 記事のレスポンス
 type ArticleResponse struct {
-	ID        uint      `json:"id"`
-	Title     string    `json:"title"`
-	Content   string    `json:"content"`
-	Published bool      `json:"published"`
-	Tags      string    `json:"tags"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID        uint      `json:"id" example:"1"`
+	Title     string    `json:"title" example:"Goプログラミングの基礎"`
+	Content   string    `json:"content" example:"Goは静的型付け言語です..."`
+	Published bool      `json:"published" example:"true"`
+	Tags      string    `json:"tags" example:"Go,プログラミング,チュートリアル"`
+	CreatedAt time.Time `json:"created_at" example:"2023-01-01T00:00:00Z"`
+	UpdatedAt time.Time `json:"updated_at" example:"2023-01-01T00:00:00Z"`
 }
-
 // ArticleからArticleResponseへの変換メソッド
 func (a *Article) ToResponse() ArticleResponse {
 	return ArticleResponse{

--- a/frontend/src/components/ArticleItem.tsx
+++ b/frontend/src/components/ArticleItem.tsx
@@ -2,18 +2,15 @@ import { FC, memo } from 'react'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/solid'
 import { useMutateArticle } from '../hooks/useMutateArticle'
 import useStore from '../store'
+import { Article } from '../types/models/article'
 import '../ArticleItem.css'
 
-interface Props {
-  id: number
-  title: string
-  content: string
-  published: boolean
-  tags: string
+// Articleから必要なプロパティのみを取り出す
+type ArticleItemProps = Required<Pick<Article, 'id' | 'title' | 'content' | 'published' | 'tags'>> & {
   onEdit: () => void
 }
 
-const ArticleItemMemo: FC<Props> = ({
+const ArticleItemMemo: FC<ArticleItemProps> = ({
   id,
   title,
   content,

--- a/frontend/src/components/ArticleManager.tsx
+++ b/frontend/src/components/ArticleManager.tsx
@@ -43,7 +43,7 @@ export const ArticleManager = () => {
 
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [updateArticle])
+  }, [editedArticle])
 
   const createNewArticle = () => {
     updateArticle({ id: 0, title: '', content: '', published: false, tags: '' })
@@ -51,7 +51,7 @@ export const ArticleManager = () => {
   }
 
   const handleSubmit = () => {
-    if (!editedArticle.title && !editedArticle.content) return
+    if (!editedArticle.title) return
     
     if (editedArticle.id === 0) {
       createArticleMutation.mutate({
@@ -61,7 +61,13 @@ export const ArticleManager = () => {
         tags: editedArticle.tags,
       })
     } else {
-      updateArticleMutation.mutate(editedArticle)
+      updateArticleMutation.mutate({
+        id: editedArticle.id,
+        title: editedArticle.title,
+        content: editedArticle.content,
+        published: editedArticle.published,
+        tags: editedArticle.tags,
+      })
     }
     setIsEditing(false)
   }
@@ -99,18 +105,18 @@ export const ArticleManager = () => {
           data.map((article) => (
             <ArticleItem
               key={article.id}
-              id={article.id}
-              title={article.title}
-              content={article.content}
-              published={article.published}
-              tags={article.tags}
+              id={article.id!}
+              title={article.title!}
+              content={article.content!}
+              published={article.published!}
+              tags={article.tags!}
               onEdit={() => {
                 updateArticle({
-                  id: article.id,
-                  title: article.title,
-                  content: article.content,
-                  published: article.published,
-                  tags: article.tags,
+                  id: article.id!,
+                  title: article.title!,
+                  content: article.content!,
+                  published: article.published!,
+                  tags: article.tags!,
                 })
                 setIsEditing(true)
               }}
@@ -185,7 +191,7 @@ export const ArticleManager = () => {
             <button 
               className="save-button" 
               onClick={handleSubmit}
-              disabled={!editedArticle.title || !editedArticle.content}
+              disabled={!editedArticle.title}
             >
               保存
             </button>

--- a/frontend/src/hooks/useMutateArticle.ts
+++ b/frontend/src/hooks/useMutateArticle.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
 import { useQueryClient, useMutation } from '@tanstack/react-query'
-import { Article } from '../types'
+import { Article, ArticleRequest } from '../types/models/article'
 import useStore from '../store'
-import { useError } from '../hooks/useError'
+import { useError } from './useError'
 
 export const useMutateArticle = () => {
   const queryClient = useQueryClient()
@@ -10,7 +10,7 @@ export const useMutateArticle = () => {
   const resetEditedArticle = useStore((state) => state.resetEditedArticle)
 
   const createArticleMutation = useMutation(
-    (article: Omit<Article, 'id' | 'created_at' | 'updated_at'>) =>
+    (article: ArticleRequest) =>
       axios.post<Article>(`${process.env.REACT_APP_API_URL}/articles`, article),
     {
       onSuccess: (res) => {
@@ -31,7 +31,7 @@ export const useMutateArticle = () => {
   )
   
   const updateArticleMutation = useMutation(
-    (article: Omit<Article, 'created_at' | 'updated_at'>) =>
+    (article: ArticleRequest & { id: number }) =>
       axios.put<Article>(`${process.env.REACT_APP_API_URL}/articles/${article.id}`, {
         title: article.title,
         content: article.content,

--- a/frontend/src/hooks/useQueryArticles.ts
+++ b/frontend/src/hooks/useQueryArticles.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { useQuery } from '@tanstack/react-query'
-import { Article } from '../types/index'
-import { useError } from '../hooks/useError'
+import { Article } from '../types/models/article'
+import { useError } from './useError'
 
 export const useQueryArticles = () => {
   const { switchErrorHandling } = useError()

--- a/frontend/src/store/slices/articleSlice.ts
+++ b/frontend/src/store/slices/articleSlice.ts
@@ -1,24 +1,16 @@
 import { StateCreator } from 'zustand';
 import { ArticleState } from '../types/articleTypes';
+import { EditedArticle, initialEditedArticle } from '../../types/models/article';
 
+/**
+ * 記事関連のZustandストアスライス
+ */
 export const createArticleSlice: StateCreator<ArticleState> = (set) => ({
-  editedArticle: {
-    id: 0,
-    title: '',
-    content: '',
-    published: false,
-    tags: ''
-  },
-  updateEditedArticle: (payload) => set({
+  editedArticle: initialEditedArticle,
+  updateEditedArticle: (payload: EditedArticle) => set({
     editedArticle: payload
   }),
-  resetEditedArticle: () => set({
-    editedArticle: {
-      id: 0,
-      title: '',
-      content: '',
-      published: false,
-      tags: ''
-    }
+  resetEditedArticle: () => set({ 
+    editedArticle: initialEditedArticle 
   }),
 });

--- a/frontend/src/store/types/articleTypes.ts
+++ b/frontend/src/store/types/articleTypes.ts
@@ -1,17 +1,7 @@
-export type ArticleState = {
-  editedArticle: {
-    id: number;
-    title: string;
-    content: string;
-    published: boolean;
-    tags: string;
-  };
-  updateEditedArticle: (payload: {
-    id: number;
-    title: string;
-    content: string;
-    published: boolean;
-    tags: string;
-  }) => void;
+import { EditedArticle } from '../../types/models/article';
+
+export interface ArticleState {
+  editedArticle: EditedArticle;
+  updateEditedArticle: (payload: EditedArticle) => void;
   resetEditedArticle: () => void;
-};
+}

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -4,6 +4,117 @@
  */
 
 export interface paths {
+  "/articles": {
+    /** ログインユーザーのすべての記事を取得する */
+    get: {
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["model.ArticleResponse"][];
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+    /** ユーザーの新しい記事を作成する */
+    post: {
+      parameters: {
+        body: {
+          /** 記事情報 */
+          article: definitions["model.ArticleRequest"];
+        };
+      };
+      responses: {
+        /** Created */
+        201: {
+          schema: definitions["model.ArticleResponse"];
+        };
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+  };
+  "/articles/{articleId}": {
+    /** 指定されたIDの記事を取得する */
+    get: {
+      parameters: {
+        path: {
+          /** 記事ID */
+          articleId: number;
+        };
+      };
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["model.ArticleResponse"];
+        };
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+    /** 指定されたIDの記事を更新する */
+    put: {
+      parameters: {
+        path: {
+          /** 記事ID */
+          articleId: number;
+        };
+        body: {
+          /** 更新する記事情報 */
+          article: definitions["model.ArticleRequest"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["model.ArticleResponse"];
+        };
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+    /** 指定されたIDの記事を削除する */
+    delete: {
+      parameters: {
+        path: {
+          /** 記事ID */
+          articleId: number;
+        };
+      };
+      responses: {
+        /** No Content */
+        204: never;
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+  };
   "/csrf-token": {
     /** CSRFトークンを取得する */
     get: {
@@ -190,6 +301,32 @@ export interface paths {
 }
 
 export interface definitions {
+  "model.ArticleRequest": {
+    /** @example Goは静的型付け言語です... */
+    content?: string;
+    /** @example true */
+    published?: boolean;
+    /** @example Go,プログラミング,チュートリアル */
+    tags?: string;
+    /** @example Goプログラミングの基礎 */
+    title: string;
+  };
+  "model.ArticleResponse": {
+    /** @example Goは静的型付け言語です... */
+    content?: string;
+    /** @example 2023-01-01T00:00:00Z */
+    created_at?: string;
+    /** @example 1 */
+    id?: number;
+    /** @example true */
+    published?: boolean;
+    /** @example Go,プログラミング,チュートリアル */
+    tags?: string;
+    /** @example Goプログラミングの基礎 */
+    title?: string;
+    /** @example 2023-01-01T00:00:00Z */
+    updated_at?: string;
+  };
   "model.CsrfTokenResponse": {
     /** @example token-string-here */
     csrf_token?: string;

--- a/frontend/src/types/models/article.ts
+++ b/frontend/src/types/models/article.ts
@@ -1,0 +1,23 @@
+import { definitions } from '../api/generated';
+
+// OpenAPIから生成された型を利用
+export type Article = definitions['model.ArticleResponse'];
+export type ArticleRequest = definitions['model.ArticleRequest'];
+
+// 編集用の型定義
+export type EditedArticle = {
+  id: number;
+  title: string;
+  content: string;
+  published: boolean;
+  tags: string;
+};
+
+// 初期値
+export const initialEditedArticle: EditedArticle = {
+  id: 0,
+  title: '',
+  content: '',
+  published: false,
+  tags: '',
+};

--- a/frontend/src/types/models/index.ts
+++ b/frontend/src/types/models/index.ts
@@ -7,8 +7,8 @@
 // タスク関連の型
 export * from './task';
 
-// // 記事関連の型
-// export * from './article';
+// 記事関連の型
+export * from './article';
 
 // // フィード関連の型
 // export * from './feed';


### PR DESCRIPTION
## 概要
### OpenAPI/Swagger を活用した型定義の共通化

 - バックエンド（Go）とフロントエンド（TypeScript/React）間での型定義を共通化するための、OpenAPI/Swagger を活用した実装。
 - API の型安全性が向上し、フロントエンドとバックエンド間の一貫性が保証される。

## 変更内容

### バックエンド側の変更

- Swagger アノテーションを使用して API エンドポイントとモデルを文書化
- `swag init` コマンドを使用して Swagger 仕様ファイル（JSON/YAML）を自動生成
- API レスポンスとリクエストの型を明確に定義

### フロントエンド側の変更

- `openapi-typescript` を使用して Swagger 仕様から TypeScript の型定義を自動生成
- 生成された型定義を React コンポーネントとフックで活用
- API 呼び出しの型安全性を確保

## 主な利点

1. **型安全性の向上**: API の変更がフロントエンドの型定義に自動的に反映されるため、型の不一致によるバグを早期に発見できるようになる。

2. **開発効率の向上**: API の仕様変更時に手動で型定義を更新する必要がなくなり、開発効率が向上。

3. **ドキュメントとしての役割**: Swagger UI を通じて API 仕様を視覚的に確認できるようになる

4. **メンテナンス性の向上**: バックエンドの変更がフロントエンドに自動的に伝播されるため、両者の同期が容易になる
 
## 実装の詳細

### 型定義の流れ

1. Go のコードに Swagger アノテーションを追加
2. `swag init` で Swagger 仕様ファイルを生成
3. `openapi-typescript` で TypeScript の型定義を生成
4. フロントエンドコードで生成された型を import して使用

### 使用例

```typescript
// OpenAPIから生成された型を利用
export type Article = definitions['model.ArticleResponse'];
export type ArticleRequest = definitions['model.ArticleRequest'];

// React Query と組み合わせて型安全な API 呼び出し
const { data, isLoading } = useQueryArticles();
```

## 今後の展望

- CI/CD パイプラインに型生成プロセスを組み込む
- API バージョニングの導入と型定義の管理
- クライアントコードの自動生成の検討

## 関連リソース

- [OpenAPI Specification](https://swagger.io/specification/)
- [swaggo/swag](https://github.com/swaggo/swag)
- [openapi-typescript](https://github.com/drwpow/openapi-typescript)

## 関連
 - close #123 