### PR TITLE
Refactor/swagger & typescript-openaiによるLayoutモデルの型定義共通化

### DIFF
--- a/backend/controller/layout_controller.go
+++ b/backend/controller/layout_controller.go
@@ -25,6 +25,15 @@ func NewLayoutController(lu usecase.ILayoutUsecase) ILayoutController {
 	return &layoutController{lu}
 }
 
+// GetAllLayouts ユーザーのすべてのレイアウトを取得
+// @Summary ユーザーのレイアウト一覧を取得
+// @Description ログインユーザーのすべてのレイアウトを取得する
+// @Tags layouts
+// @Accept json
+// @Produce json
+// @Success 200 {array} model.LayoutResponse
+// @Failure 500 {object} map[string]string
+// @Router /layouts [get]
 func (lc *layoutController) GetAllLayouts(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -35,6 +44,17 @@ func (lc *layoutController) GetAllLayouts(c echo.Context) error {
 	return c.JSON(http.StatusOK, layoutsRes)
 }
 
+// GetLayoutById 指定されたIDのレイアウトを取得
+// @Summary 特定のレイアウトを取得
+// @Description 指定されたIDのレイアウトを取得する
+// @Tags layouts
+// @Accept json
+// @Produce json
+// @Param layoutId path int true "レイアウトID"
+// @Success 200 {object} model.LayoutResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /layouts/{layoutId} [get]
 func (lc *layoutController) GetLayoutById(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -51,6 +71,17 @@ func (lc *layoutController) GetLayoutById(c echo.Context) error {
 	return c.JSON(http.StatusOK, layoutRes)
 }
 
+// CreateLayout 新しいレイアウトを作成
+// @Summary 新しいレイアウトを作成
+// @Description ユーザーの新しいレイアウトを作成する
+// @Tags layouts
+// @Accept json
+// @Produce json
+// @Param layout body model.LayoutRequest true "レイアウト情報"
+// @Success 201 {object} model.LayoutResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /layouts [post]
 func (lc *layoutController) CreateLayout(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -67,6 +98,18 @@ func (lc *layoutController) CreateLayout(c echo.Context) error {
 	return c.JSON(http.StatusCreated, layoutRes)
 }
 
+// UpdateLayout 既存のレイアウトを更新
+// @Summary レイアウトを更新
+// @Description 指定されたIDのレイアウトを更新する
+// @Tags layouts
+// @Accept json
+// @Produce json
+// @Param layoutId path int true "レイアウトID"
+// @Param layout body model.LayoutRequest true "更新するレイアウト情報"
+// @Success 200 {object} model.LayoutResponse
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /layouts/{layoutId} [put]
 func (lc *layoutController) UpdateLayout(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	
@@ -89,6 +132,17 @@ func (lc *layoutController) UpdateLayout(c echo.Context) error {
 	return c.JSON(http.StatusOK, layoutRes)
 }
 
+// DeleteLayout レイアウトを削除
+// @Summary レイアウトを削除
+// @Description 指定されたIDのレイアウトを削除する
+// @Tags layouts
+// @Accept json
+// @Produce json
+// @Param layoutId path int true "レイアウトID"
+// @Success 204 "No Content"
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /layouts/{layoutId} [delete]
 func (lc *layoutController) DeleteLayout(c echo.Context) error {
 	userId := getUserIdFromToken(c)
 	

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -275,6 +275,243 @@ const docTemplate = `{
                 }
             }
         },
+        "/layouts": {
+            "get": {
+                "description": "ログインユーザーのすべてのレイアウトを取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "ユーザーのレイアウト一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.LayoutResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "ユーザーの新しいレイアウトを作成する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "新しいレイアウトを作成",
+                "parameters": [
+                    {
+                        "description": "レイアウト情報",
+                        "name": "layout",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/layouts/{layoutId}": {
+            "get": {
+                "description": "指定されたIDのレイアウトを取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "特定のレイアウトを取得",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "レイアウトID",
+                        "name": "layoutId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "指定されたIDのレイアウトを更新する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "レイアウトを更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "レイアウトID",
+                        "name": "layoutId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新するレイアウト情報",
+                        "name": "layout",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "指定されたIDのレイアウトを削除する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "レイアウトを削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "レイアウトID",
+                        "name": "layoutId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "post": {
                 "description": "既存ユーザーのログイン処理",
@@ -704,6 +941,83 @@ const docTemplate = `{
                 "csrf_token": {
                     "type": "string",
                     "example": "token-string-here"
+                }
+            }
+        },
+        "model.LayoutComponentResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "layout_id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "integer"
+                },
+                "x": {
+                    "type": "integer"
+                },
+                "y": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.LayoutRequest": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "example": "ブログのメインレイアウト"
+                }
+            }
+        },
+        "model.LayoutResponse": {
+            "type": "object",
+            "properties": {
+                "components": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.LayoutComponentResponse"
+                    }
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "title": {
+                    "type": "string",
+                    "example": "ブログのメインレイアウト"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -272,6 +272,243 @@
                 }
             }
         },
+        "/layouts": {
+            "get": {
+                "description": "ログインユーザーのすべてのレイアウトを取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "ユーザーのレイアウト一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.LayoutResponse"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "ユーザーの新しいレイアウトを作成する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "新しいレイアウトを作成",
+                "parameters": [
+                    {
+                        "description": "レイアウト情報",
+                        "name": "layout",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/layouts/{layoutId}": {
+            "get": {
+                "description": "指定されたIDのレイアウトを取得する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "特定のレイアウトを取得",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "レイアウトID",
+                        "name": "layoutId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "指定されたIDのレイアウトを更新する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "レイアウトを更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "レイアウトID",
+                        "name": "layoutId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新するレイアウト情報",
+                        "name": "layout",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.LayoutResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "指定されたIDのレイアウトを削除する",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "layouts"
+                ],
+                "summary": "レイアウトを削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "レイアウトID",
+                        "name": "layoutId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "post": {
                 "description": "既存ユーザーのログイン処理",
@@ -701,6 +938,83 @@
                 "csrf_token": {
                     "type": "string",
                     "example": "token-string-here"
+                }
+            }
+        },
+        "model.LayoutComponentResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "layout_id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "width": {
+                    "type": "integer"
+                },
+                "x": {
+                    "type": "integer"
+                },
+                "y": {
+                    "type": "integer"
+                }
+            }
+        },
+        "model.LayoutRequest": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "example": "ブログのメインレイアウト"
+                }
+            }
+        },
+        "model.LayoutResponse": {
+            "type": "object",
+            "properties": {
+                "components": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.LayoutComponentResponse"
+                    }
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "title": {
+                    "type": "string",
+                    "example": "ブログのメインレイアウト"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2023-01-01T00:00:00Z"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -47,6 +47,58 @@ definitions:
         example: token-string-here
         type: string
     type: object
+  model.LayoutComponentResponse:
+    properties:
+      content:
+        type: string
+      created_at:
+        type: string
+      height:
+        type: integer
+      id:
+        type: integer
+      layout_id:
+        type: integer
+      name:
+        type: string
+      type:
+        type: string
+      updated_at:
+        type: string
+      width:
+        type: integer
+      x:
+        type: integer
+      "y":
+        type: integer
+    type: object
+  model.LayoutRequest:
+    properties:
+      title:
+        example: ブログのメインレイアウト
+        type: string
+    required:
+    - title
+    type: object
+  model.LayoutResponse:
+    properties:
+      components:
+        items:
+          $ref: '#/definitions/model.LayoutComponentResponse'
+        type: array
+      created_at:
+        example: "2023-01-01T00:00:00Z"
+        type: string
+      id:
+        example: 1
+        type: integer
+      title:
+        example: ブログのメインレイアウト
+        type: string
+      updated_at:
+        example: "2023-01-01T00:00:00Z"
+        type: string
+    type: object
   model.TaskRequest:
     properties:
       title:
@@ -283,6 +335,163 @@ paths:
       summary: CSRFトークン取得
       tags:
       - users
+  /layouts:
+    get:
+      consumes:
+      - application/json
+      description: ログインユーザーのすべてのレイアウトを取得する
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.LayoutResponse'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: ユーザーのレイアウト一覧を取得
+      tags:
+      - layouts
+    post:
+      consumes:
+      - application/json
+      description: ユーザーの新しいレイアウトを作成する
+      parameters:
+      - description: レイアウト情報
+        in: body
+        name: layout
+        required: true
+        schema:
+          $ref: '#/definitions/model.LayoutRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.LayoutResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 新しいレイアウトを作成
+      tags:
+      - layouts
+  /layouts/{layoutId}:
+    delete:
+      consumes:
+      - application/json
+      description: 指定されたIDのレイアウトを削除する
+      parameters:
+      - description: レイアウトID
+        in: path
+        name: layoutId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: レイアウトを削除
+      tags:
+      - layouts
+    get:
+      consumes:
+      - application/json
+      description: 指定されたIDのレイアウトを取得する
+      parameters:
+      - description: レイアウトID
+        in: path
+        name: layoutId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.LayoutResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: 特定のレイアウトを取得
+      tags:
+      - layouts
+    put:
+      consumes:
+      - application/json
+      description: 指定されたIDのレイアウトを更新する
+      parameters:
+      - description: レイアウトID
+        in: path
+        name: layoutId
+        required: true
+        type: integer
+      - description: 更新するレイアウト情報
+        in: body
+        name: layout
+        required: true
+        schema:
+          $ref: '#/definitions/model.LayoutRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.LayoutResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: レイアウトを更新
+      tags:
+      - layouts
   /login:
     post:
       consumes:

--- a/backend/model/layout.go
+++ b/backend/model/layout.go
@@ -4,30 +4,29 @@ import "time"
 
 // データベースモデル
 type Layout struct {
-	ID         uint              `json:"id" gorm:"primaryKey"`
-	Title      string            `json:"title" gorm:"not null"`
-	UserId     uint              `json:"user_id" gorm:"not null"`
+	ID         uint              `json:"id" gorm:"primaryKey" example:"1"`
+	Title      string            `json:"title" gorm:"not null" example:"ブログのメインレイアウト"`
+	UserId     uint              `json:"user_id" gorm:"not null" example:"1"`
 	User       User              `json:"-" gorm:"foreignKey:UserId; constraint:OnDelete:CASCADE"`
 	Components []LayoutComponent `json:"-" gorm:"foreignKey:LayoutId"`
-	CreatedAt  time.Time         `json:"created_at"`
-	UpdatedAt  time.Time         `json:"updated_at"`
+	CreatedAt  time.Time         `json:"created_at" example:"2023-01-01T00:00:00Z"`
+	UpdatedAt  time.Time         `json:"updated_at" example:"2023-01-01T00:00:00Z"`
 }
 
 // リクエスト用の構造体
 type LayoutRequest struct {
-	Title  string `json:"title" validate:"required"`
+	Title  string `json:"title" validate:"required" example:"ブログのメインレイアウト"`
 	UserId uint   `json:"-"` // クライアントからは送信されず、JWTから取得
 }
 
 // レスポンス用の構造体
 type LayoutResponse struct {
-	ID         uint                     `json:"id"`
-	Title      string                   `json:"title"`
+	ID         uint                     `json:"id" example:"1"`
+	Title      string                   `json:"title" example:"ブログのメインレイアウト"`
 	Components []LayoutComponentResponse `json:"components,omitempty"`
-	CreatedAt  time.Time                `json:"created_at"`
-	UpdatedAt  time.Time                `json:"updated_at"`
+	CreatedAt  time.Time                `json:"created_at" example:"2023-01-01T00:00:00Z"`
+	UpdatedAt  time.Time                `json:"updated_at" example:"2023-01-01T00:00:00Z"`
 }
-
 // LayoutからLayoutResponseへの変換メソッド
 func (l *Layout) ToResponse() LayoutResponse {
 	response := LayoutResponse{

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
     axios.defaults.withCredentials = true
     const getCsrfToken = async () => {
       const { data } = await axios.get<CsrfToken>(
-        `${process.env.REACT_APP_API_URL}/csrf`
+        `${process.env.REACT_APP_API_URL}/csrf-token`
       )
       axios.defaults.headers.common['X-CSRF-Token'] = data.csrf_token
     }

--- a/frontend/src/api/layouts.ts
+++ b/frontend/src/api/layouts.ts
@@ -1,57 +1,39 @@
 import axios from 'axios';
 import { Layout } from '../types';
 
-// Layoutの作成、更新時に使用するインターフェース
-interface LayoutInput {
-  id?: number;
-  title: string;
-}
-
-/**
- * 全てのレイアウトを取得
- */
+// レイアウト一覧を取得
 export const fetchLayouts = async (): Promise<Layout[]> => {
-  const response = await axios.get(`${process.env.REACT_APP_API_URL}/layouts`, {
-    withCredentials: true
-  });
-  return response.data;
+  const { data } = await axios.get<Layout[]>(
+    `${process.env.REACT_APP_API_URL}/layouts`,
+    { withCredentials: true }
+  );
+  return data;
 };
 
-/**
- * 指定IDのレイアウトを取得
- */
-export const fetchLayout = async (id: number): Promise<Layout> => {
-  const response = await axios.get(`${process.env.REACT_APP_API_URL}/layouts/${id}`, {
-    withCredentials: true
-  });
-  return response.data;
+// 新規レイアウト作成
+export const createLayout = async (layout: { title: string }): Promise<Layout> => {
+  const { data } = await axios.post<Layout>(
+    `${process.env.REACT_APP_API_URL}/layouts`,
+    layout,
+    { withCredentials: true }
+  );
+  return data;
 };
 
-/**
- * 新規レイアウトを作成
- */
-export const createLayout = async (layout: LayoutInput): Promise<Layout> => {
-  const response = await axios.post(`${process.env.REACT_APP_API_URL}/layouts`, layout, {
-    withCredentials: true
-  });
-  return response.data;
+// レイアウト更新
+export const updateLayout = async (id: number, layout: { title: string }): Promise<Layout> => {
+  const { data } = await axios.put<Layout>(
+    `${process.env.REACT_APP_API_URL}/layouts/${id}`,
+    layout,
+    { withCredentials: true }
+  );
+  return data;
 };
 
-/**
- * レイアウトを更新
- */
-export const updateLayout = async (id: number, layout: LayoutInput): Promise<Layout> => {
-  const response = await axios.put(`${process.env.REACT_APP_API_URL}/layouts/${id}`, layout, {
-    withCredentials: true
-  });
-  return response.data;
-};
-
-/**
- * レイアウトを削除
- */
+// レイアウト削除
 export const deleteLayout = async (id: number): Promise<void> => {
-  await axios.delete(`${process.env.REACT_APP_API_URL}/layouts/${id}`, {
-    withCredentials: true
-  });
+  await axios.delete(
+    `${process.env.REACT_APP_API_URL}/layouts/${id}`,
+    { withCredentials: true }
+  );
 };

--- a/frontend/src/store/slices/layoutSlice.ts
+++ b/frontend/src/store/slices/layoutSlice.ts
@@ -1,32 +1,26 @@
 import { StateCreator } from 'zustand';
 import { LayoutState, LayoutComponentState } from '../types/layoutTypes';
+import { EditedLayout, EditedLayoutComponent, initialEditedLayout, initialEditedLayoutComponent } from '../../types/models/layout';
 
+/**
+ * レイアウト関連のZustandストアスライス
+ */
 export const createLayoutSlice: StateCreator<LayoutState> = (set) => ({
-  editedLayout: {
-    id: 0,
-    title: ''
-  },
-  updateEditedLayout: (payload) => set({
+  editedLayout: initialEditedLayout,
+  updateEditedLayout: (payload: EditedLayout) => set({
     editedLayout: payload
   }),
-  resetEditedLayout: () => set({ editedLayout: {
-    id: 0,
-    title: '' 
-  } }),
+  resetEditedLayout: () => set({ 
+    editedLayout: initialEditedLayout 
+  }),
 });
 
 export const createLayoutComponentSlice: StateCreator<LayoutComponentState> = (set) => ({
-  editedLayoutComponent: {
-    id: 0,
-    title: '',
-    layout_id: 0
-  },
-  updateEditedLayoutComponent: (payload) => set({
+  editedLayoutComponent: initialEditedLayoutComponent,
+  updateEditedLayoutComponent: (payload: EditedLayoutComponent) => set({
     editedLayoutComponent: payload
   }),
-  resetEditedLayoutComponent: () => set({ editedLayoutComponent: {
-    id: 0,
-    title: '',
-    layout_id: 0
-  } }),
+  resetEditedLayoutComponent: () => set({ 
+    editedLayoutComponent: initialEditedLayoutComponent 
+  }),
 });

--- a/frontend/src/store/types/layoutTypes.ts
+++ b/frontend/src/store/types/layoutTypes.ts
@@ -1,25 +1,13 @@
-export type LayoutState = {
-  editedLayout: {
-    id: number;
-    title: string
-  };
-  updateEditedLayout: (payload: {
-    id: number;
-    title: string
-  }) => void;
-  resetEditedLayout: () => void;
-};
+import { EditedLayout, EditedLayoutComponent } from '../../types/models/layout';
 
-export type LayoutComponentState = {
-  editedLayoutComponent: {
-    id: number;
-    title: string;
-    layout_id: number;
-  };
-  updateEditedLayoutComponent: (payload: {
-    id: number;
-    title: string;
-    layout_id: number;
-  }) => void;
+export interface LayoutState {
+  editedLayout: EditedLayout;
+  updateEditedLayout: (payload: EditedLayout) => void;
+  resetEditedLayout: () => void;
+}
+
+export interface LayoutComponentState {
+  editedLayoutComponent: EditedLayoutComponent;
+  updateEditedLayoutComponent: (payload: EditedLayoutComponent) => void;
   resetEditedLayoutComponent: () => void;
-};
+}

--- a/frontend/src/types/api/generated.ts
+++ b/frontend/src/types/api/generated.ts
@@ -126,6 +126,117 @@ export interface paths {
       };
     };
   };
+  "/layouts": {
+    /** ログインユーザーのすべてのレイアウトを取得する */
+    get: {
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["model.LayoutResponse"][];
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+    /** ユーザーの新しいレイアウトを作成する */
+    post: {
+      parameters: {
+        body: {
+          /** レイアウト情報 */
+          layout: definitions["model.LayoutRequest"];
+        };
+      };
+      responses: {
+        /** Created */
+        201: {
+          schema: definitions["model.LayoutResponse"];
+        };
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+  };
+  "/layouts/{layoutId}": {
+    /** 指定されたIDのレイアウトを取得する */
+    get: {
+      parameters: {
+        path: {
+          /** レイアウトID */
+          layoutId: number;
+        };
+      };
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["model.LayoutResponse"];
+        };
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+    /** 指定されたIDのレイアウトを更新する */
+    put: {
+      parameters: {
+        path: {
+          /** レイアウトID */
+          layoutId: number;
+        };
+        body: {
+          /** 更新するレイアウト情報 */
+          layout: definitions["model.LayoutRequest"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["model.LayoutResponse"];
+        };
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+    /** 指定されたIDのレイアウトを削除する */
+    delete: {
+      parameters: {
+        path: {
+          /** レイアウトID */
+          layoutId: number;
+        };
+      };
+      responses: {
+        /** No Content */
+        204: never;
+        /** Bad Request */
+        400: {
+          schema: { [key: string]: string };
+        };
+        /** Internal Server Error */
+        500: {
+          schema: { [key: string]: string };
+        };
+      };
+    };
+  };
   "/login": {
     /** 既存ユーザーのログイン処理 */
     post: {
@@ -330,6 +441,34 @@ export interface definitions {
   "model.CsrfTokenResponse": {
     /** @example token-string-here */
     csrf_token?: string;
+  };
+  "model.LayoutComponentResponse": {
+    content?: string;
+    created_at?: string;
+    height?: number;
+    id?: number;
+    layout_id?: number;
+    name?: string;
+    type?: string;
+    updated_at?: string;
+    width?: number;
+    x?: number;
+    y?: number;
+  };
+  "model.LayoutRequest": {
+    /** @example ブログのメインレイアウト */
+    title: string;
+  };
+  "model.LayoutResponse": {
+    components?: definitions["model.LayoutComponentResponse"][];
+    /** @example 2023-01-01T00:00:00Z */
+    created_at?: string;
+    /** @example 1 */
+    id?: number;
+    /** @example ブログのメインレイアウト */
+    title?: string;
+    /** @example 2023-01-01T00:00:00Z */
+    updated_at?: string;
   };
   "model.TaskRequest": {
     /** @example 買い物に行く */

--- a/frontend/src/types/models/index.ts
+++ b/frontend/src/types/models/index.ts
@@ -10,8 +10,8 @@ export * from './task';
 // 記事関連の型
 export * from './article';
 
-// // フィード関連の型
+// フィード関連の型
 // export * from './feed';
 
-// // レイアウト関連の型
-// export * from './layout';
+// レイアウト関連の型
+export * from './layout';

--- a/frontend/src/types/models/layout.ts
+++ b/frontend/src/types/models/layout.ts
@@ -1,0 +1,42 @@
+// Layoutモデルの型定義
+export type Layout = {
+  id: number;
+  title: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+// 編集中のLayoutの状態を表す型
+export type EditedLayout = {
+  id: number;
+  title: string;
+};
+
+// 初期状態
+export const initialEditedLayout: EditedLayout = {
+  id: 0,
+  title: ''
+};
+
+// LayoutComponentの型定義
+export type LayoutComponent = {
+  id: number;
+  title: string;
+  layout_id: number;
+  type?: string;
+  content?: string;
+};
+
+// 編集中のLayoutComponentの状態
+export type EditedLayoutComponent = {
+  id: number;
+  title: string;
+  layout_id: number;
+};
+
+// 初期状態
+export const initialEditedLayoutComponent: EditedLayoutComponent = {
+  id: 0,
+  title: '',
+  layout_id: 0
+};


### PR DESCRIPTION
## 概要
### Swagger定義とTypeScript型の共通化
 - バックエンド（Go）で定義されているSwagger仕様と、フロントエンド（TypeScript）で使用している型定義を共通化
 - Swaggerから自動生成された型定義に統一することで、APIの変更に対する堅牢性の向上

## 変更内容

### 1. 型定義の共通化
- `frontend/src/types/models/layout.ts`で独自に定義していた型を、`frontend/src/types/api/generated.ts`の自動生成された型定義を使用するように変更
- Zustandストアで使用する型も、Swagger定義から生成された型をベースに拡張するように修正

### 2. API呼び出しの統一
- `frontend/src/api/layouts.ts`のAPI呼び出し関数を、Swagger定義に基づいた型を使用するように更新
- リクエスト・レスポンスの型を自動生成された型に置き換え

### 3. コンポーネントの型適用
- 各Reactコンポーネントで使用している型参照を更新
- 特に`LayoutManager`コンポーネントなど、レイアウト関連のコンポーネントの型を統一

## メリット
1. **型の一貫性**: バックエンドとフロントエンドで同じ型定義を使用することで、不整合を防止
2. **保守性の向上**: APIの変更があった場合、Swaggerファイルを更新するだけで型定義が自動的に更新される
3. **開発効率の向上**: 手動での型定義メンテナンスが不要になり、開発リソースを節約
4. **バグの減少**: 型の不一致によるランタイムエラーを事前に防止

## 実装方針
1. Swaggerから生成された型定義を基本とし、必要に応じて拡張型を定義
2. 既存の型定義は段階的に置き換え、互換性を維持
3. 自動生成された型と手動定義の型の二重管理を排除

## 今後の課題
- CI/CDパイプラインでのSwagger型定義の自動生成プロセスの確立
- バックエンドAPI変更時の型チェック自動化

## 関連ドキュメント
- [Swagger仕様](backend/docs/swagger.yaml)
- [TypeScript型定義](frontend/src/types/api/generated.ts)

## 関連
 - close #123 