### PR TITLE
feature/frontend > レイアウトエディタのDnD操作機能の実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,10 @@
         "axios": "^1.3.4",
         "d3": "^7.9.0",
         "react": "^18.2.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
+        "react-grid-layout": "^1.5.1",
         "react-markdown": "^10.0.0",
         "react-router-dom": "^6.10.0",
         "react-scripts": "5.0.1",
@@ -40,6 +43,7 @@
         "zustand": "^4.3.6"
       },
       "devDependencies": {
+        "@types/react-grid-layout": "^1.3.5",
         "openapi-typescript": "^5.4.1"
       }
     },
@@ -3759,6 +3763,24 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
+    },
     "node_modules/@remix-run/router": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
@@ -4922,6 +4944,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-grid-layout": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.5.tgz",
+      "integrity": "sha512-WH/po1gcEcoR6y857yAnPGug+ZhkF4PaTUxgAbwfeSH/QOgVSakKHBXoPGad/sEznmkiaK3pqHk+etdWisoeBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -8427,6 +8459,17 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -9750,6 +9793,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -17067,6 +17116,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -17080,11 +17168,52 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.1.tgz",
+      "integrity": "sha512-4Fr+kKMk0+m1HL/BWfHxi/lRuaOmDNNKQDcu7m12+NEYcen20wIuZFo789u3qWCyvUsNUxCiyf0eKq4WiJSNYw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.5",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -17126,6 +17255,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
+      "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
       }
     },
     "node_modules/react-router": {
@@ -17307,6 +17449,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -17582,6 +17733,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,10 @@
     "axios": "^1.3.4",
     "d3": "^7.9.0",
     "react": "^18.2.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
+    "react-grid-layout": "^1.5.1",
     "react-markdown": "^10.0.0",
     "react-router-dom": "^6.10.0",
     "react-scripts": "5.0.1",
@@ -60,6 +63,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-grid-layout": "^1.3.5",
     "openapi-typescript": "^5.4.1"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { ArticleEditorPage } from './pages/ArticleEditorPage'
 import { HatenaPage } from './pages/HatenaPage'
 import RouteMapPage from './pages/RouteMapPage'
 import { FeedArticlesPage } from './pages/FeedArticlesPage'
+import LayoutEditorPage from './pages/LayoutEditorPage'
 
 function App() {
   useEffect(() => {
@@ -42,6 +43,9 @@ function App() {
         <Route path="/article-editor-page" element={<ArticleEditorPage />} />
         <Route path="/route-map" element={<RouteMapPage />} />
         <Route path="/feed-articles" element={<FeedArticlesPage />} />
+        
+        {/* Add the new layout editor route with a URL parameter for layoutId */}
+        <Route path="/layout-editor/:layoutId" element={<LayoutEditorPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/api/layoutApi.ts
+++ b/frontend/src/api/layoutApi.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { definitions } from '../types/api/generated';
+
+const API_URL = process.env.REACT_APP_API_URL || '';
+
+// レイアウトコンポーネント一覧を取得
+export const fetchLayoutComponents = async (): Promise<definitions['model.LayoutComponentResponse'][]> => {
+  const response = await axios.get(`${API_URL}/layout-components`);
+  return response.data;
+};
+
+// 特定のレイアウトを取得
+export const fetchLayout = async (layoutId: number): Promise<definitions['model.LayoutResponse']> => {
+  const response = await axios.get(`${API_URL}/layouts/${layoutId}`);
+  return response.data;
+};
+
+// コンポーネントをレイアウトに割り当て
+export const assignComponentToLayout = async (
+  componentId: number,
+  layoutId: number,
+  data: definitions['model.AssignLayoutRequest']
+): Promise<void> => {
+  await axios.post(`${API_URL}/layout-components/${componentId}/assign/${layoutId}`, data);
+};
+
+// コンポーネントの位置を更新
+export const updateComponentPosition = async (
+  componentId: number,
+  position: definitions['model.PositionRequest']
+): Promise<void> => {
+  await axios.put(`${API_URL}/layout-components/${componentId}/position`, { position });
+};
+
+// コンポーネントをレイアウトから削除
+export const removeComponentFromLayout = async (componentId: number): Promise<void> => {
+  await axios.delete(`${API_URL}/layout-components/${componentId}/assign`);
+};

--- a/frontend/src/api/layoutApi.ts
+++ b/frontend/src/api/layoutApi.ts
@@ -29,7 +29,8 @@ export const updateComponentPosition = async (
   componentId: number,
   position: definitions['model.PositionRequest']
 ): Promise<void> => {
-  await axios.put(`${API_URL}/layout-components/${componentId}/position`, { position });
+  // APIのエンドポイントとリクエスト形式を確認
+  await axios.put(`${API_URL}/layout-components/${componentId}/position`, position);
 };
 
 // コンポーネントをレイアウトから削除

--- a/frontend/src/components/ComponentPalette.tsx
+++ b/frontend/src/components/ComponentPalette.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useDrag } from 'react-dnd';
+import { definitions } from '../types/api/generated';
+
+interface ComponentPaletteProps {
+  components: definitions['model.LayoutComponentResponse'][];
+}
+
+// ドラッグ可能なコンポーネントアイテム
+const DraggableComponent: React.FC<{
+  component: definitions['model.LayoutComponentResponse'];
+}> = ({ component }) => {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: 'COMPONENT',
+    item: { id: component.id },
+    collect: (monitor) => ({
+      isDragging: !!monitor.isDragging(),
+    }),
+  }));
+
+  return (
+    <div
+      ref={drag}
+      className="draggable-component"
+      style={{
+        opacity: isDragging ? 0.5 : 1,
+        cursor: 'move',
+        padding: '10px',
+        margin: '5px',
+        border: '1px solid #ccc',
+        backgroundColor: '#f9f9f9',
+      }}
+    >
+      <div>{component.name}</div>
+      <div>Type: {component.type}</div>
+    </div>
+  );
+};
+
+const ComponentPalette: React.FC<ComponentPaletteProps> = ({ components }) => {
+  // すべてのコンポーネントを表示する（フィルタリングを削除）
+  return (
+    <div className="component-palette">
+      {components.length === 0 ? (
+        <p>利用可能なコンポーネントがありません</p>
+      ) : (
+        components.map((component) => (
+          <DraggableComponent key={component.id} component={component} />
+        ))
+      )}
+    </div>
+  );
+};
+
+export default ComponentPalette;

--- a/frontend/src/components/LayoutCanvas.tsx
+++ b/frontend/src/components/LayoutCanvas.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { useDrop } from 'react-dnd';
+import GridLayout from 'react-grid-layout';
+import { definitions } from '../types/api/generated';
+
+interface LayoutCanvasProps {
+  layout: definitions['model.LayoutResponse'] | null;
+  onDrop: (componentId: number) => void;
+  onLayoutChange: (layout: any[]) => void;
+}
+
+const LayoutCanvas: React.FC<LayoutCanvasProps> = ({ layout, onDrop, onLayoutChange }) => {
+  // ドロップ領域の設定
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: 'COMPONENT',
+    drop: (item: { id: number }) => {
+      onDrop(item.id);
+      return { name: 'LayoutCanvas' };
+    },
+    collect: (monitor) => ({
+      isOver: !!monitor.isOver(),
+    }),
+  }));
+
+  // GridLayoutで使用するレイアウト設定を生成
+  const gridItems = layout?.components?.map(component => ({
+    i: component.id!.toString(),
+    x: component.x || 0,
+    y: component.y || 0,
+    w: component.width || 2,
+    h: component.height || 2,
+    component
+  })) || [];
+
+  return (
+    <div
+      ref={drop}
+      className="layout-canvas"
+      style={{
+        width: '100%',
+        height: '600px',
+        border: `2px dashed ${isOver ? 'green' : '#ccc'}`,
+        backgroundColor: isOver ? 'rgba(0, 255, 0, 0.1)' : '#f0f0f0',
+        padding: '10px',
+        position: 'relative',
+      }}
+    >
+      {layout?.components && layout.components.length > 0 ? (
+        <GridLayout
+          className="layout"
+          layout={gridItems}
+          cols={12}
+          rowHeight={30}
+          width={1000}
+          onLayoutChange={onLayoutChange}
+          draggableHandle=".component-drag-handle"
+        >
+          {gridItems.map(item => (
+            <div key={item.i} className="grid-item">
+              <div className="component-drag-handle" style={{ cursor: 'move', padding: '5px', backgroundColor: '#eee' }}>
+                {item.component.name}
+              </div>
+              <div className="component-content" dangerouslySetInnerHTML={{ __html: item.component.content || '' }} />
+            </div>
+          ))}
+        </GridLayout>
+      ) : (
+        <div className="empty-layout">
+          <p>コンポーネントをここにドラッグしてください</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LayoutCanvas;

--- a/frontend/src/components/LayoutCanvas.tsx
+++ b/frontend/src/components/LayoutCanvas.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 import { useDrop } from 'react-dnd';
 import GridLayout from 'react-grid-layout';
 import { definitions } from '../types/api/generated';
+import { TrashIcon } from '@heroicons/react/24/solid'; // HeroIconsを使用
 
 interface LayoutCanvasProps {
   layout: definitions['model.LayoutResponse'] | null;
   onDrop: (componentId: number) => void;
   onLayoutChange: (layout: any[]) => void;
+  onRemoveComponent: (componentId: number) => void; // 削除機能を追加
 }
 
-const LayoutCanvas: React.FC<LayoutCanvasProps> = ({ layout, onDrop, onLayoutChange }) => {
+const LayoutCanvas: React.FC<LayoutCanvasProps> = ({ 
+  layout, 
+  onDrop, 
+  onLayoutChange,
+  onRemoveComponent 
+}) => {
   // ドロップ領域の設定
   const [{ isOver }, drop] = useDrop(() => ({
     accept: 'COMPONENT',
@@ -57,8 +64,28 @@ const LayoutCanvas: React.FC<LayoutCanvasProps> = ({ layout, onDrop, onLayoutCha
         >
           {gridItems.map(item => (
             <div key={item.i} className="grid-item">
-              <div className="component-drag-handle" style={{ cursor: 'move', padding: '5px', backgroundColor: '#eee' }}>
-                {item.component.name}
+              <div className="component-header" style={{ 
+                display: 'flex', 
+                justifyContent: 'space-between', 
+                alignItems: 'center',
+                padding: '5px', 
+                backgroundColor: '#eee' 
+              }}>
+                <div className="component-drag-handle" style={{ cursor: 'move' }}>
+                  {item.component.name}
+                </div>
+                <button
+                  onClick={() => onRemoveComponent(parseInt(item.i))}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#ff4d4f'
+                  }}
+                  title="コンポーネントを削除"
+                >
+                  <TrashIcon style={{ width: '20px', height: '20px' }} />
+                </button>
               </div>
               <div className="component-content" dangerouslySetInnerHTML={{ __html: item.component.content || '' }} />
             </div>

--- a/frontend/src/components/LayoutEditor.tsx
+++ b/frontend/src/components/LayoutEditor.tsx
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import GridLayout from 'react-grid-layout';
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+import { definitions } from '../types/api/generated';
+import ComponentPalette from './ComponentPalette';
+import LayoutCanvas from './LayoutCanvas';
+import { useQueryLayoutComponents } from '../hooks/useQueryLayoutComponents';
+import { fetchLayout, assignComponentToLayout, updateComponentPosition } from '../api/layoutApi';
+import axios from 'axios';
+
+interface LayoutEditorProps {
+  layoutId: number;
+}
+
+const LayoutEditor: React.FC<LayoutEditorProps> = ({ layoutId }) => {
+  // useQueryLayoutComponentsフックを使用してコンポーネントを取得
+  const { data: components, isLoading: componentsLoading, refetch } = useQueryLayoutComponents();
+  const [layout, setLayout] = useState<definitions['model.LayoutResponse'] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadLayout = async () => {
+      try {
+        setLoading(true);
+        // レイアウトを取得
+        const layoutData = await fetchLayout(layoutId);
+        setLayout(layoutData);
+      } catch (error) {
+        console.error('Failed to load layout:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadLayout();
+  }, [layoutId]);
+
+  // コンポーネントをレイアウトに追加する処理
+  const handleDrop = async (componentId: number) => {
+    try {
+      // 初期位置とサイズを設定
+      const position = {
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 2
+      };
+
+      // APIを呼び出してコンポーネントをレイアウトに割り当て
+      await assignComponentToLayout(componentId, layoutId, {
+        layout_id: layoutId,
+        position
+      });
+
+      // レイアウトを再取得して表示を更新
+      const updatedLayout = await fetchLayout(layoutId);
+      setLayout(updatedLayout);
+      // コンポーネント一覧も更新
+      refetch();
+    } catch (error) {
+      console.error('Failed to assign component:', error);
+    }
+  };
+
+  // レイアウト内のコンポーネント位置変更処理
+  const handleLayoutChange = async (newLayout: any[]) => {
+    if (!layout || !layout.components) return;
+
+    // 変更されたコンポーネントの位置を更新
+    for (const item of newLayout) {
+      const component = layout.components.find(c => c.id === parseInt(item.i));
+      if (component) {
+        try {
+          await updateComponentPosition(component.id!, {
+            x: item.x,
+            y: item.y,
+            width: item.w,
+            height: item.h
+          });
+        } catch (error) {
+          console.error(`Failed to update position for component ${item.i}:`, error);
+        }
+      }
+    }
+
+    // レイアウトを再取得
+    const updatedLayout = await fetchLayout(layoutId);
+    setLayout(updatedLayout);
+  };
+
+  // 新しいコンポーネントを作成する関数
+  const handleCreateComponent = async () => {
+    try {
+      // APIを呼び出して新しいコンポーネントを作成
+      await axios.post(`${process.env.REACT_APP_API_URL}/layout-components`, {
+        name: `新しいコンポーネント ${Date.now()}`,
+        type: 'text',
+        content: '<p>ここにコンテンツを入力</p>'
+      });
+      
+      // コンポーネント一覧を更新
+      refetch();
+    } catch (error) {
+      console.error('Failed to create component:', error);
+    }
+  };
+
+  if (loading || componentsLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div className="layout-editor">
+        <h2>{layout?.title} エディタ</h2>
+        
+        <div className="layout-editor-container">
+          {/* コンポーネントパレット（ドラッグ元） */}
+          <div className="component-palette">
+            <h3>コンポーネント</h3>
+            <button 
+              onClick={handleCreateComponent}
+              style={{
+                padding: '8px 12px',
+                margin: '10px 0',
+                backgroundColor: '#4CAF50',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              新規コンポーネント作成
+            </button>
+            <ComponentPalette components={components || []} />
+          </div>
+          
+          {/* レイアウトキャンバス（ドロップ先） */}
+          <div className="layout-canvas">
+            <h3>レイアウト</h3>
+            <LayoutCanvas 
+              layout={layout} 
+              onDrop={handleDrop}
+              onLayoutChange={handleLayoutChange}
+            />
+          </div>
+        </div>
+      </div>
+    </DndProvider>
+  );
+};
+
+export default LayoutEditor;

--- a/frontend/src/components/LayoutItem.tsx
+++ b/frontend/src/components/LayoutItem.tsx
@@ -15,6 +15,7 @@ export const LayoutItem = ({ id, title, onEdit }: LayoutItemProps) => {
   const { deleteLayoutMutation } = useMutateLayout()
   return (
     <li className="layout-item">
+      <span className="layout-id">{id}</span>
       <span className="layout-title">{title}</span>
       <div className="layout-actions">
         <button 

--- a/frontend/src/pages/LayoutEditorPage.tsx
+++ b/frontend/src/pages/LayoutEditorPage.tsx
@@ -1,0 +1,20 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import LayoutEditor from '../components/LayoutEditor';
+
+const LayoutEditorPage: React.FC = () => {
+  const { layoutId } = useParams<{ layoutId: string }>();
+  
+  if (!layoutId) {
+    return <div>レイアウトIDが指定されていません</div>;
+  }
+
+  return (
+    <div className="layout-editor-page">
+      <h1>レイアウトエディタ</h1>
+      <LayoutEditor layoutId={parseInt(layoutId)} />
+    </div>
+  );
+};
+
+export default LayoutEditorPage;

--- a/frontend/src/styles/LayoutEditor.css
+++ b/frontend/src/styles/LayoutEditor.css
@@ -1,0 +1,50 @@
+.layout-editor {
+  padding: 20px;
+}
+
+.layout-editor-container {
+  display: flex;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.component-palette {
+  width: 250px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 10px;
+  background-color: #f5f5f5;
+}
+
+.layout-canvas {
+  flex: 1;
+  min-height: 600px;
+}
+
+.draggable-component {
+  transition: all 0.2s;
+}
+
+.draggable-component:hover {
+  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}
+
+.grid-item {
+  border: 1px solid #ccc;
+  background-color: white;
+  overflow: hidden;
+}
+
+.component-content {
+  padding: 10px;
+  height: calc(100% - 30px);
+  overflow: auto;
+}
+
+.empty-layout {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  color: #999;
+}


### PR DESCRIPTION
## レイアウトエディタのドラッグ＆ドロップ機能実装
レイアウトエディタにおけるコンポーネントの操作機能を実装

## 実装内容
### 1. コンポーネントのドラッグ＆ドロップ割り当て
- コンポーネントパレットからレイアウトキャンバスへのDnD操作を実装
- React DnDライブラリを使用して直感的なUI操作を実現
- ドロップ時に自動的にAPIを呼び出してバックエンドと同期

### 2. レイアウト内でのコンポーネント位置更新
- React Grid Layoutを使用したグリッドベースの配置システム
- ドラッグによる位置変更とリサイズ機能
- 位置変更時にリアルタイムでバックエンドと同期

### 3. コンポーネントの削除機能
- 各コンポーネントに削除ボタンを追加
- 削除時にAPIを呼び出してバックエンドと同期
- 削除後の表示を自動更新

### 4. 新規コンポーネント作成機能
- 「新規コンポーネント作成」ボタンを追加
- 作成したコンポーネントをすぐにドラッグ可能

## 技術的な詳細

- **React DnD**: ドラッグ＆ドロップ操作の基盤として使用
- **React Grid Layout**: レイアウト内のコンポーネント配置に使用
- **Axios**: バックエンドAPIとの通信
- **React Query**: データフェッチングと状態管理
- **HeroIcons**: UIアイコンの実装

## 今後の改善点

- コンポーネントのプレビュー機能の強化
- undo/redo機能の追加
- レイアウトテンプレートの保存と再利用
- コンポーネント間の依存関係の管理

## テスト方法

1. `/layout-manager`にアクセスし、任意のレイアウトの「編集」ボタンをクリック
2. コンポーネントパレットからコンポーネントをドラッグしてキャンバスにドロップ
3. キャンバス上のコンポーネントをドラッグして位置を変更
4. コンポーネントの右上にある削除アイコンをクリックして削除
5. 「新規コンポーネント作成」ボタンをクリックして新しいコンポーネントを作成

## 関連Issue
 - close #45 
   - close #130 
   - close #131 
   - close #132